### PR TITLE
domd: fix the name of the interface in tsn0.network

### DIFF
--- a/meta-xt-driver-domain-gen4/recipes-connectivity/xen-network/files/tsn0.network
+++ b/meta-xt-driver-domain-gen4/recipes-connectivity/xen-network/files/tsn0.network
@@ -1,5 +1,5 @@
 [Match]
-Name=eth0
+Name=tsn0
 
 [Network]
 DHCP=yes


### PR DESCRIPTION
Fixes: 1ea1a254e465 ("domd: configure wait online to depend on tsn0")

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>