### PR TITLE
domd: install pciutils

### DIFF
--- a/meta-xt-domd-gen4/recipes-core/images/rcar-image-minimal.bbappend
+++ b/meta-xt-domd-gen4/recipes-core/images/rcar-image-minimal.bbappend
@@ -1,0 +1,3 @@
+IMAGE_INSTALL += " \
+    pciutils \
+"


### PR DESCRIPTION
They are needed to examine PCI devices during development.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>