### PR TITLE
Add DomU

### DIFF
--- a/meta-xt-prod-devel-rcar-control-gen4/recipes-guests/domu/files/domu-set-root
+++ b/meta-xt-prod-devel-rcar-control-gen4/recipes-guests/domu/files/domu-set-root
@@ -12,7 +12,19 @@ fi
 
 # Special case for NFS - we want to quite different cmd line
 if [ $BOOT_STORAGE = nfs ] ; then
-    BOOT_STR="nfs nfsroot=192.168.1.100:\/srv\/domu,vers=3 ip=dhcp"
+    SERVER_IP=`cat /proc/device-tree/boot_dev/nfs_server_ip  | tr -d '\000'`
+    NFS_DIR=`cat /proc/device-tree/boot_dev/domu_nfs_dir | tr -d '\000'`
+    if [ -z "$SERVER_IP" ] ; then
+	SERVER_IP="192.168.1.100"
+	echo "WARNING! Using default server ip address ${SERVER_IP}"
+    fi
+    if [ -z "$NFS_DIR" ] ; then
+	NFS_DIR="/srv/domu"
+	echo "WARNING! Using default NFS directory ${NFS_DIR}"
+    fi
+    BOOT_STR="nfs nfsroot=${SERVER_IP}:${NFS_DIR},vers=3 ip=dhcp"
+    # Escape slahes ( / ->\/ )
+    BOOT_STR=`echo "${BOOT_STR}" | sed "s/\//\\\\\\\\\//g"`
     echo "Mangling domain configuration: setting storage to network boot"
     sed -i "s/xvda1/${BOOT_STR}/" $DOMU_CFG_FILE
     sed -i "s/disk = /# disk = /" $DOMU_CFG_FILE

--- a/prod-devel-rcar-s4.yaml
+++ b/prod-devel-rcar-s4.yaml
@@ -159,6 +159,9 @@ components:
     build-dir: "%{YOCTOS_WORK_DIR}"
     sources:
       - *COMMON_SOURCES
+      - type: git
+        url: https://github.com/renesas-rcar/meta-renesas.git
+        rev: dunfell
     builder:
       type: yocto
       work_dir: "%{DOMU_BUILD_DIR}"
@@ -171,12 +174,10 @@ components:
         - "../meta-openembedded/meta-oe"
         - "../meta-openembedded/meta-filesystems"
         - "../meta-openembedded/meta-python"
-        - "../meta-renesas/meta-rcar-gen3"
+        - "../meta-renesas/meta-rcar-gateway"
         - "../meta-xt-common/meta-xt-domu"
-        - "../meta-xt-rcar/meta-xt-rcar-fixups"
         - "../meta-xt-prod-devel-rcar-gen4/meta-xt-domu-gen4"
-        - "../meta-xt-prod-devel-rcar-gen4/meta-xt-rcar-bsp-gen4"
-      build_target: core-image-minimal
+      build_target: rcar-image-minimal
       target_images:
         - "tmp/deploy/images/%{MACHINE}/Image"
 


### PR DESCRIPTION
This patch series enables back DomU build, fixes ARM trusted firmware, so it don't interfere with Xen operation and enables back all 4 cores + OP-TEE.