### PR TITLE
domd: do not map vPCI MMIOs for pciec0

### DIFF
--- a/meta-xt-prod-devel-rcar-control-gen4/recipes-guests/domd/files/domd-spider.cfg
+++ b/meta-xt-prod-devel-rcar-control-gen4/recipes-guests/domd/files/domd-spider.cfg
@@ -215,8 +215,8 @@ iomem = [
     "ffd63,1",
 #dma-controller@ffd63000
     "ffd80,10",
-#pcie@e65d0000
-    "e65d0,3",
+#pcie@e65d0000 - trapped by vPCI code: "dbi"
+#    "e65d0,3",
 #pcie@e65d0000
     "e65d3,2",
 #pcie@e65d0000
@@ -225,8 +225,8 @@ iomem = [
     "e65d6,1",
 #pcie@e65d0000
     "e65d7,1",
-#pcie@e65d0000
-    "fe000,10",
+#pcie@e65d0000 - trapped by vPCI code: "config"
+#    "fe000,10",
 #thermal@e6198000
     "e6198,1",
     "e61a0,1",


### PR DESCRIPTION
There are two MMIO regions which are trapped and emulated by vPCI in Xen:
"dbi" and "config", so do not map these into DomD.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>