### PR TITLE
yaml: fix path to dom0 kernel image

### DIFF
--- a/prod-devel-rcar-s4.yaml
+++ b/prod-devel-rcar-s4.yaml
@@ -116,7 +116,7 @@ components:
       additional_deps:
         - "%{DOMD_BUILD_DIR}/tmp/deploy/images/%{MACHINE}/Image"
       target_images:
-        - "tmp/deploy/images/yocto-generic/Image"
+        - "tmp/deploy/images/generic-armv8-xt/Image"
   domd:
     build-dir: "%{YOCTOS_WORK_DIR}"
     sources:


### PR DESCRIPTION
In this product yocto stores artifacts in generic-armv8-xt, not in
yocto-generic.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>