### PR TITLE
yaml: switch meta-renesas to dunfell branch

### DIFF
--- a/prod-devel-rcar-s4.yaml
+++ b/prod-devel-rcar-s4.yaml
@@ -126,7 +126,7 @@ components:
       - *COMMON_SOURCES
       - type: git
         url: https://github.com/renesas-rcar/meta-renesas.git
-        rev: Renesas-Yocto-v5.8.2_S4
+        rev: dunfell
       - type: git
         url: git://git.yoctoproject.org/meta-selinux
         rev: 46bcf05
@@ -165,7 +165,7 @@ components:
       - *COMMON_SOURCES
       - type: git
         url: https://github.com/renesas-rcar/meta-renesas.git
-        rev: Renesas-Yocto-v5.8.2_S4
+        rev: dunfell
     builder:
       type: yocto
       work_dir: "%{DOMU_BUILD_DIR}"


### PR DESCRIPTION
Move meta-renesas from fixed tag Renesas-Yocto-v5.8.2_S4 to dunfell
branch, this will allow us to track latest Renesas development,
including switch to rc8 kernel.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>