### PR TITLE
xen.dts: Update PCI IOMMU bindings according to the recent changes

### DIFF
--- a/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas/r8a779f0-spider-xen.dts
+++ b/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas/r8a779f0-spider-xen.dts
@@ -149,15 +149,17 @@
 };
 
 &pciec0 {
-	iommu-map = <0x0 &ipmmu_hc 32 0x1>;
-	iommu-map-mask = <0x0>;
-	xen,force-assign-without-iommu;
+	iommus = <&ipmmu_hc 32>;
+	iommu-map = <0x0 &ipmmu_hc 32 0x1>,
+				<0x100 &ipmmu_hc 33 0x1>;
+	iommu-map-mask = <0xff00>;
 };
 
 &pciec1 {
-	iommu-map = <0x0 &ipmmu_hc 48 0x1>;
-	iommu-map-mask = <0x0>;
-	xen,force-assign-without-iommu;
+	iommus = <&ipmmu_hc 48>;
+	iommu-map = <0x0 &ipmmu_hc 48 0x1>,
+				<0x100 &ipmmu_hc 49 0x1>;
+	iommu-map-mask = <0xff00>;
 };
 
 &dmac1			{ xen,passthrough; };


### PR DESCRIPTION
As Xen has gained basic PCIE-IPMMU OSID support we can now update
bindings to describe which uTLB(s)/OSID(s) to use for particular
PCI device(s) represented by RID(BDF).

As it is not completely clear at the moment what devices we are going
to have and how to group (or separate) them describe the simple use-case
for now which can and will be adjusted later on.

As device and function bits are masked out all devices with bus
number 0 are mastered via uTLB corresponding to the OSID 0 and
all devices with bus number 1 via uTLB corresponding to the OSID 1.

Also restore "iommus" and remove "xen,force-assign-without-iommu"
property for the sake of removing the hack to allow assigning
platform side of host bridge without IOMMU, hopefully we have OSID
resources for doing that. But this of course can be reconsidered.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>