### PR TITLE
basefiles: don't change owner of /var/log to nobody

### DIFF
--- a/meta-xt-domd-gen4/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-xt-domd-gen4/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,7 @@
+
+# meta-renesas does strange things with fstab file to fix own problems
+# with NFS. We don't have such problems, so we need to revert some changes
+# made by Renesas. Namely, we want /var/volatile to be owned by root.
+do_install_append() {
+    sed -i "s/uid=65534,gid=65534/defaults/" ${D}${sysconfdir}/fstab
+}


### PR DESCRIPTION
For some reason Renesas changes ownership of /var/volatile to nobody.
This scares systemd-tmpfiles, as it now sees symlink from root-owned
/var/log to nobody-owned /var/volatile/log and refuses to create
directories like /var/log/xen.

Revert this change so system can work properly.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>