### PR TITLE
xen-network: Remove SYSTEMD_SERVICE_${PN} as duplicated

### DIFF
--- a/meta-xt-driver-domain-gen4/recipes-connectivity/xen-network/xen-network.bbappend
+++ b/meta-xt-driver-domain-gen4/recipes-connectivity/xen-network/xen-network.bbappend
@@ -1,7 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SYSTEMD_SERVICE_${PN} = "bridge-up-notification.service"
-
 SRC_URI += "\
     file://systemd-networkd-wait-online.conf \
     file://tsn0.network \


### PR DESCRIPTION
This definition is added to xen-network.bb

-----
Need to be merged AFTER https://github.com/xen-troops/meta-xt-common/pull/20 