### PR TITLE
Set priority of layers to 12

### DIFF
--- a/meta-xt-dom0-gen4/conf/layer.conf
+++ b/meta-xt-dom0-gen4/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "xt-dom0-gen4"
 BBFILE_PATTERN_xt-dom0-gen4 := "^${LAYERDIR}/"
-BBFILE_PRIORITY_xt-dom0-gen4 = "6"
+BBFILE_PRIORITY_xt-dom0-gen4 = "12"
 
 LAYERSERIES_COMPAT_xt-dom0-gen4 = "dunfell"
 

--- a/meta-xt-domd-gen4/conf/layer.conf
+++ b/meta-xt-domd-gen4/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "meta-xt-domd-gen4"
 BBFILE_PATTERN_meta-xt-domd-gen4 := "^${LAYERDIR}/"
-BBFILE_PRIORITY_meta-xt-domd-gen4 = "6"
+BBFILE_PRIORITY_meta-xt-domd-gen4 = "12"
 
 LAYERSERIES_COMPAT_meta-xt-domd-gen4 = "dunfell"
 

--- a/meta-xt-domu-gen4/conf/layer.conf
+++ b/meta-xt-domu-gen4/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "meta-xt-domu-gen4"
 BBFILE_PATTERN_meta-xt-domu-gen4 := "^${LAYERDIR}/"
-BBFILE_PRIORITY_meta-xt-domu-gen4 = "6"
+BBFILE_PRIORITY_meta-xt-domu-gen4 = "12"
 
 LAYERSERIES_COMPAT_meta-xt-domu-gen4 = "dunfell"
 

--- a/meta-xt-domx-gen4/conf/layer.conf
+++ b/meta-xt-domx-gen4/conf/layer.conf
@@ -13,7 +13,7 @@ rcar-gateway:${LAYERDIR}/recipes-bsp/optee/*.bbappend \
 
 BBFILE_COLLECTIONS += "xt-domx-gen4"
 BBFILE_PATTERN_xt-domx-gen4 := "^${LAYERDIR}/"
-BBFILE_PRIORITY_xt-domx-gen4 = "6"
+BBFILE_PRIORITY_xt-domx-gen4 = "12"
 
 LAYERSERIES_COMPAT_xt-domx-gen4 = "dunfell"
 

--- a/meta-xt-driver-domain-gen4/conf/layer.conf
+++ b/meta-xt-driver-domain-gen4/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "xt-driver-domain-gen4"
 BBFILE_PATTERN_xt-driver-domain-gen4 := "^${LAYERDIR}/"
-BBFILE_PRIORITY_xt-driver-domain-gen4 = "6"
+BBFILE_PRIORITY_xt-driver-domain-gen4 = "12"
 
 LAYERSERIES_COMPAT_xt-driver-domain-gen4 = "dunfell"
 

--- a/meta-xt-prod-devel-rcar-control-gen4/conf/layer.conf
+++ b/meta-xt-prod-devel-rcar-control-gen4/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "xt-prod-devel-rcar-control-gen4"
 BBFILE_PATTERN_xt-prod-devel-rcar-control-gen4 := "^${LAYERDIR}/"
-BBFILE_PRIORITY_xt-prod-devel-rcar-control-gen4 = "7"
+BBFILE_PRIORITY_xt-prod-devel-rcar-control-gen4 = "12"
 
 LAYERSERIES_COMPAT_xt-prod-devel-rcar-control-gen4 = "dunfell"
 


### PR DESCRIPTION
To make sure that specific components can override/redefine settings from more generic levels, we set the following priorities for levels:

```
meta-xt-common     -  8
meta-xt-<platform> - 10
meta-xt-<product>  - 12
```

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>