### PR TITLE
domd: u-boot: fix rswitch GWCA issue

### DIFF
--- a/meta-xt-domd-gen4/recipes-bsp/u-boot/files/0001-net-rswtich-disable-GWCA-when-removing-driver.patch
+++ b/meta-xt-domd-gen4/recipes-bsp/u-boot/files/0001-net-rswtich-disable-GWCA-when-removing-driver.patch
@@ -1,0 +1,53 @@
+From 49b7693ddb9ec4e1593e594b2ac19747cf366809 Mon Sep 17 00:00:00 2001
+From: Volodymyr Babchuk <volodymyr_babchuk@epam.com>
+Date: Thu, 2 Feb 2023 23:39:13 +0200
+Subject: [PATCH] net: rswtich: disable GWCA when removing driver
+
+We need to disable GWCA for two reasons:
+
+1. There may be packets coming to the device when U-Boot already
+transferred control to Linux, but Linux didn't had chance to
+re-configure GWCA. This may lead to memory corruption, as chains are
+already active.
+
+2. Linux will not be able to switch GWCA to DISABLED state, because
+transition from OPERATION to DISABLED requires that all buffer
+pointers are released and all transactions are finished. But there are
+no one who can handle those operations, as U-Boot already exited and
+Linux is still trying to initialize R-Switch driver.
+
+This fixes issue with DomD unable to initialize network in the
+parallel mode.
+
+Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>
+---
+ drivers/net/rswitch.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/net/rswitch.c b/drivers/net/rswitch.c
+index daebd80ff9..2fd0f52582 100644
+--- a/drivers/net/rswitch.c
++++ b/drivers/net/rswitch.c
+@@ -1328,6 +1328,7 @@ err_mdio_alloc:
+ static int rswitch_remove(struct udevice *dev)
+ {
+ 	struct rswitch_priv *priv = dev_get_priv(dev);
++	int ret;
+ 
+ 	if (!priv->parallel_mode) {
+ 		clk_disable(&priv->rsw_clk);
+@@ -1337,6 +1338,11 @@ static int rswitch_remove(struct udevice *dev)
+ 		mdio_unregister(priv->etha.bus);
+ 	}
+ 
++	/* Turn off GWCA to make sure that there will be no new packets */
++	ret = rswitch_gwca_change_mode(priv, GWMC_OPC_DISABLE);
++	if (ret)
++		pr_err("Failed to disable GWCA: %d\n", ret);
++
+ 	unmap_physmem(priv->addr, MAP_NOCACHE);
+ 	unmap_physmem(priv->etha.serdes_addr, MAP_NOCACHE);
+ 
+-- 
+2.38.1
+

--- a/meta-xt-domd-gen4/recipes-bsp/u-boot/u-boot_2020.10.bbappend
+++ b/meta-xt-domd-gen4/recipes-bsp/u-boot/u-boot_2020.10.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+    file://0001-net-rswtich-disable-GWCA-when-removing-driver.patch \
+"


### PR DESCRIPTION
Add patch that disables GWCA in rswitch_remove to avoid several issues that can be occurred after u-boot transfers control to Linux.