### PR TITLE
Set memory bank to the free memory for rcar_spider

### DIFF
--- a/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas/r8a779f0-spider-xen.dts
+++ b/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas/r8a779f0-spider-xen.dts
@@ -11,7 +11,7 @@
 	memory@48000000 {
 		device_type = "memory";
 		/* first 128MB is reserved for secure area. */
-		reg = <0x0 0x48000000 0x0 0x78000000
+		reg = <0x0 0x48000000 0x0 0x58000000
 		       0x4 0x80000000 0x0 0x80000000>;
 	};
 
@@ -19,6 +19,11 @@
 		#address-cells = <2>;
 		#size-cells = <2>;
 		ranges;
+
+		cr54_mem {
+			no-map;
+			reg = <0x00 0x58000000 0x00 0x20000000>;
+		};
 
 		/* ICCOM CR Shared memory */
 		cr_cta_mem {


### PR DESCRIPTION
According to the commit d3218a4df ("arm64: dts: renesas: r8a779f0: spider-cpu: Reserve memory for Realtime core"), added by Phong Hoang to the renesas kernel [0], the last 512MB of the first memory bank is reserved for CR.
So we have to move ram address to bank2 so it will not overlap the existing memory and make reserved-region to forbid XEN from using this memory.

[0] https://github.com/renesas-rcar/linux-bsp.git