### PR TITLE
HACK: disable PCIE devices for spider-4.17.0 branch

### DIFF
--- a/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas/r8a779f0-spider-domd.dts
+++ b/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas/r8a779f0-spider-domd.dts
@@ -127,3 +127,8 @@
 &ufs {
         status = "okay";
 };
+
+/delete-node/&pciec0;
+/delete-node/&pciec0_ep;
+/delete-node/&pciec1;
+/delete-node/&pciec1_ep;


### PR DESCRIPTION
spider-4.17.0 branch does not have any VPCI-related patches, which leads to DomD crash with PCIE enabled. Remove these node from device tree temporary (until PCI/SRIOV patches will not be ported).