### PR TITLE
Fix branch for xt-common and update DomD's Linux

### DIFF
--- a/prod-devel-rcar-s4.yaml
+++ b/prod-devel-rcar-s4.yaml
@@ -14,7 +14,7 @@ variables:
   SOC_FAMILY: "r8a779f0"
   XT_DOMD_CONFIG_NAME: "domd-spider.cfg"
   XT_DOMU_CONFIG_NAME: "domu-spider.cfg"
-  XT_KERNEL_BRANCH: "v5.10.41/rcar-5.1.7.rc6-xt"
+  XT_KERNEL_BRANCH: "v5.10.41/rcar-5.1.7.rc11-xt"
   XT_KERNEL_REV: "${AUTOREV}"
 common_data:
   # Sources used by all yocto-based domains

--- a/prod-devel-rcar-s4.yaml
+++ b/prod-devel-rcar-s4.yaml
@@ -30,7 +30,7 @@ common_data:
       rev: 180241e
     - type: git
       url: "https://github.com/xen-troops/meta-xt-common.git"
-      rev: master
+      rev: dunfell
     - type: git
       url: "https://github.com/xen-troops/meta-xt-prod-devel-rcar-gen4.git"
       rev: master


### PR DESCRIPTION
- yaml: use dunfell branch for meta-xt-common
- domd: Update version of linux

Have to be merged with https://github.com/xen-troops/meta-xt-prod-devel-rcar-gen4/pull/63