### PR TITLE
domd: update node names for v5.10.41/rcar-5.1.7.rc11 Xen device tree

### DIFF
--- a/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas/r8a779f0-spider-xen.dts
+++ b/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas/r8a779f0-spider-xen.dts
@@ -256,7 +256,8 @@
 &hscif1			{ xen,passthrough; };
 &rswitch		{ xen,passthrough; };
 &tsc			{ xen,passthrough; };
-&iccom00		{ xen,passthrough; };
+&mailbox		{ xen,passthrough; };
+&iccom_reg00		{ xen,passthrough; };
 &rtdmac_control0_00     { xen,passthrough; };
 &rtdmac_control0_01     { xen,passthrough; };
 &rtdmac_control0_02     { xen,passthrough; };
@@ -352,6 +353,7 @@
 		iommus = <&ipmmu_hc 7>, <&ipmmu_hc 23>;
 	};
 
+	iccom00		{ xen,passthrough; };
 	iccom01		{ xen,passthrough; };
 	iccom02		{ xen,passthrough; };
 	iccom03		{ xen,passthrough; };


### PR DESCRIPTION
Renesas kernel revision v5.10.41/rcar-5.1.7.rc11 contains updated device tree nodes, that break Xen hypervisor device tree build. Update them, according to Renesas changes.