### PR TITLE
domd: tag mfis_mbox node as xen,passthrough

### DIFF
--- a/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas/r8a779f0-spider-xen.dts
+++ b/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas/r8a779f0-spider-xen.dts
@@ -353,6 +353,7 @@
 		iommus = <&ipmmu_hc 7>, <&ipmmu_hc 23>;
 	};
 
+	mfis_mbox	{ xen,passthrough; };
 	iccom00		{ xen,passthrough; };
 	iccom01		{ xen,passthrough; };
 	iccom02		{ xen,passthrough; };


### PR DESCRIPTION
mfix_mbox and iccom015 share the same IRQ number hence have to be tagged for passthrough the same way. Otherwise dom0 won't let domain be created if it's configured with iccom015 device.