### PR TITLE
domu: linux: Fix defconfig related warning

### DIFF
--- a/meta-xt-domu-gen4/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/meta-xt-domu-gen4/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -6,7 +6,6 @@ SRCREV = "${XT_KERNEL_REV}"
 
 SRC_URI_append = "\
     file://r8a779f0-spider-domu.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
-    file://defconfig \
     file://rswitch.cfg \
     file://dmatest.cfg \
     file://ixgbevf.cfg \


### PR DESCRIPTION
We have defconfig referenced twice for DomU's linux-renesas:
  - KBUILD_DEFCONFIG
  - SRC_URI

Ths results in two warnings during build time:
  - `defconfig detected in WORKDIR. defconfig skipped`
  - `defconfig was supplied both via KBUILD_DEFCONFIG and SRC_URI. Dropping SRC_URI defconfig`.

This commit removes not used defconfig from SRC_URI.