### PR TITLE
OP-TEE: Fix memory layout and fix baremetal crashes

### DIFF
--- a/meta-xt-domx-gen4/recipes-bsp/optee/files/0001-plat-rcar_gen4-extend-memory-available-to-OP-TEE.patch
+++ b/meta-xt-domx-gen4/recipes-bsp/optee/files/0001-plat-rcar_gen4-extend-memory-available-to-OP-TEE.patch
@@ -1,56 +1,57 @@
-From 07844f3b5e5c293b11a2c93b3c027be518073efb Mon Sep 17 00:00:00 2001
+From 7b243cd01706c898a404c7f6ea0214b8c79b923d Mon Sep 17 00:00:00 2001
 From: Volodymyr Babchuk <volodymyr_babchuk@epam.com>
-Date: Thu, 21 Apr 2022 16:49:53 +0300
-Subject: [PATCH] plat-rcar_gen4: extend memory available to OP-TEE
+Date: Thu, 25 Jan 2024 04:05:49 +0200
+Subject: [PATCH 1/2] plat-rcar_gen4: extend memory available to OP-TEE
 
-Reclaim memory that was designated for BL3, as it is not used.
-Move all special areas to end of secure RAM and extend TA_RAM_SIZE
-to 54MB.
+There is a bit of unused memory between OP-TEE and BL31 so we can move
+portions of the OP-TEE regions further back. Also we can reduce
+TEE_RAM_VA_SIZE by one megabyte. All this will allow us to get 29MB
+for TA RAM, which is crucial in virtualized setup.
 
 Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>
 ---
- core/arch/arm/plat-rcar_gen4/platform_config.h | 12 ++++++------
- 1 file changed, 6 insertions(+), 6 deletions(-)
+ core/arch/arm/plat-rcar_gen4/platform_config.h | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
 
 diff --git a/core/arch/arm/plat-rcar_gen4/platform_config.h b/core/arch/arm/plat-rcar_gen4/platform_config.h
-index 58530b0c..8103e4a5 100644
+index 58530b0cd..c34ac1bd8 100644
 --- a/core/arch/arm/plat-rcar_gen4/platform_config.h
 +++ b/core/arch/arm/plat-rcar_gen4/platform_config.h
-@@ -50,7 +50,7 @@
-  * but is smaller due to SECTION_SIZE alignment, can be fixed once
-  * OP-TEE OS is mapped using small pages instead.
+@@ -52,26 +52,26 @@
   */
--#define TZDRAM_SIZE		(0x02400000U)
-+#define TZDRAM_SIZE		(0x03E00000U)
+ #define TZDRAM_SIZE		(0x02400000U)
  
- #define TEE_RAM_VA_SIZE		(1024 * 1024 * 3)
+-#define TEE_RAM_VA_SIZE		(1024 * 1024 * 3)
++#define TEE_RAM_VA_SIZE		(1024 * 1024 * 2)
  
-@@ -58,20 +58,20 @@
- #define TEE_RAM_PH_SIZE		(0x00300000U)	/* TEE RAM size		*/
+ #define TEE_RAM_START		(0x44100000)	/* TEE RAM address	*/
+-#define TEE_RAM_PH_SIZE		(0x00300000U)	/* TEE RAM size		*/
++#define TEE_RAM_PH_SIZE		(0x00200000U)	/* TEE RAM size		*/
  
- #define TA_RAM_START		(0x44400000U)	/* TA RAM address	*/
+-#define TA_RAM_START		(0x44400000U)	/* TA RAM address	*/
 -#define TA_RAM_SIZE		(0x01800000U)	/* TA RAM size		*/
-+#define TA_RAM_SIZE		(0x03600000U)	/* TA RAM size		*/
++#define TA_RAM_START		(0x44300000U)	/* TA RAM address	*/
++#define TA_RAM_SIZE		(0x01D00000U)	/* TA RAM size		*/
  
  #define TEE_SHMEM_START		(0x47E00000U)	/* Share Memory address	*/
  #define TEE_SHMEM_SIZE		(0x00100000U)	/* Share Memory size	*/
  
 -#define OPTEE_LOG_BASE		(0x45E00000U)	/* OP-TEE Log Area address */
-+#define OPTEE_LOG_BASE		(0x47B00000U)	/* OP-TEE Log Area address */
++#define OPTEE_LOG_BASE		(0x46100000U)	/* OP-TEE Log Area address */
  #define OPTEE_LOG_NS_BASE	(0x47FEC000U)	/* OP-TEE Log Area NS addr */
  #define OPTEE_LOG_NS_SIZE	(0x00014000U)   /* OP-TEE Log Area NS size */
  
 -#define TA_VERIFICATION_BASE	(0x45C00000U)	/* TA area for verification */
-+#define TA_VERIFICATION_BASE	(0x47A00000U)	/* TA area for verification */
++#define TA_VERIFICATION_BASE	(0x46000000U)	/* TA area for verification */
  #define TA_VERIFICATION_SIZE	(0x00100000U)	/* TA verification size */
 -#define CRYPTOENGINE_WORK_BASE	(0x46000000U)	/* Crypto Enegine Work area */
-+#define CRYPTOENGINE_WORK_BASE	(0x47D00000U)	/* Crypto Enegine Work area */
++#define CRYPTOENGINE_WORK_BASE	(0x46300000U)	/* Crypto Enegine Work area */
  
 -#define NONCACHE_WORK_BASE	(0x45F00000U)	/* Non Cache Area address */
-+#define NONCACHE_WORK_BASE	(0x47C00000U)	/* Non Cache Area address */
++#define NONCACHE_WORK_BASE	(0x46200000U)	/* Non Cache Area address */
  #define NONCACHE_WORK_SIZE	(0x00100000U)	/* Non Cache Area Size */
  
  #define ICU_FW_SHMEM_BASE	(0x41C00000U)	/* ICU FW Share Memory address */
 -- 
-2.38.1
+2.43.0
 

--- a/meta-xt-domx-gen4/recipes-bsp/optee/files/0002-arm-virtualization-don-t-allow-hypervisor-to-issue-s.patch
+++ b/meta-xt-domx-gen4/recipes-bsp/optee/files/0002-arm-virtualization-don-t-allow-hypervisor-to-issue-s.patch
@@ -1,0 +1,101 @@
+From 57df5a2b5ddd6788f8d32874382a00f07050db62 Mon Sep 17 00:00:00 2001
+From: Volodymyr Babchuk <volodymyr_babchuk@epam.com>
+Date: Thu, 18 Jan 2024 00:38:27 +0200
+Subject: [PATCH 2/2] arm: virtualization: don't allow hypervisor to issue std
+ calls
+
+There is standing issue with having two versions of OP-TEE binary:
+with virtualization enabled and without it. Correct variant needs to
+be present on board before booting rest of the system.
+
+If non-virtualized variant is present and user tries to boot a
+hypervisor, hypervisor can (and should) detect that OP-TEE does not
+provide OPTEE_SMC_SEC_CAP_VIRTUALIZATION capability and fail
+gracefully.
+
+On other hand, when virtualized variant of OP-TEE is booted, but user
+then boots directly into Linux (or any other OS), OP-TEE crashes:
+
+E/TC:0 0 0 Core data-abort at address 0xffffffffffffffa0 (translation fault)
+E/TC:0 0 0  esr 0x96000044  ttbr0 0x4418d000   ttbr1 0x00000000   cidr 0x0
+E/TC:0 0 0  cpu #0          cpsr 0x00000184
+E/TC:0 0 0  x0  0000000032000004 x1  0000000000000004
+E/TC:0 0 0  x2  000000008183c000 x3  0000000000000000
+E/TC:0 0 0  x4  0000000000000000 x5  0000000000000000
+E/TC:0 0 0  x6  0000000000000000 x7  0000000000000000
+E/TC:0 0 0  x8  0000000000000000 x9  0000000000000000
+E/TC:0 0 0  x10 0000000000000000 x11 0000000000000000
+E/TC:0 0 0  x12 0000000000000000 x13 0000000000000000
+E/TC:0 0 0  x14 0000000000000000 x15 0000000000000000
+E/TC:0 0 0  x16 0000000000000000 x17 0000000000000000
+E/TC:0 0 0  x18 0000000000000000 x19 0000000000000000
+E/TC:0 0 0  x20 0000000000000000 x21 0000000000000000
+E/TC:0 0 0  x22 0000000000000000 x23 0000000000000000
+E/TC:0 0 0  x24 0000000000000000 x25 0000000000000000
+E/TC:0 0 0  x26 0000000000000000 x27 0000000000000000
+E/TC:0 0 0  x28 0000000000000000 x29 0000000000000000
+E/TC:0 0 0  x30 0000000044103ce4 elr 0000000044106314
+E/TC:0 0 0  sp_el0 0000000000000000
+E/TC:0 0 0 TEE load address @ 0x44100000
+E/TC:0 0 0 Call stack:
+E/TC:0 0 0  0x44106314 thread_handle_std_smc at core/arch/arm/kernel/thread_optee_smc.c:62
+E/TC:0 0 0 Panic 'unhandled pageable abort' at core/arch/arm/kernel/abort.c:584 <abort_handler>
+E/TC:0 0 0 TEE load address @ 0x44100000
+E/TC:0 0 0 Call stack:
+E/TC:0 0 0  0x44107e14 print_kernel_stack at core/arch/arm/kernel/unwind_arm64.c:89
+E/TC:0 0 0  0x44114ffc __do_panic at core/kernel/panic.c:73
+E/TC:0 0 0  0x44107050 get_fault_type at core/arch/arm/kernel/abort.c:500
+
+This crash happens because virtualization code has special case for
+guest_id == HYP_CLNT_ID. This case is needed to allow hypervisor to
+call fast SMCs, so it can check OP-TEE version, capabilities and ask
+OP-TEE to create/destroy guest partitions. Problem is that
+thread_handle_std_smc() assumes that virt_set_guest() really sets the
+guest partition, which does not happen in this special case.
+
+This patch removes this special case from virt_set_guest(). Instead
+thread_handle_fast_smc() function checks for HYP_CLNT_ID explicitly.
+
+If hypervisor really want to be able to issue STD calls, it should
+create a partition for itself using OPTEE_SMC_VM_CREATED call.
+
+With this patch applied, virtualized variant of OP-TEE does not crash
+anymore when users tries to boot into a baremetal setup.
+
+Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>
+Reviewed-by: Jens Wiklander <jens.wiklander@linaro.org>
+Acked-by: Etienne Carriere <etienne.carriere@foss.st.com>
+---
+ core/arch/arm/kernel/thread_optee_smc.c | 2 +-
+ core/arch/arm/kernel/virtualization.c   | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/core/arch/arm/kernel/thread_optee_smc.c b/core/arch/arm/kernel/thread_optee_smc.c
+index 567528def..a2640374b 100644
+--- a/core/arch/arm/kernel/thread_optee_smc.c
++++ b/core/arch/arm/kernel/thread_optee_smc.c
+@@ -38,7 +38,7 @@ void thread_handle_fast_smc(struct thread_smc_args *args)
+ 	thread_check_canaries();
+ 
+ #ifdef CFG_VIRTUALIZATION
+-	if (!virt_set_guest(args->a7)) {
++	if (!virt_set_guest(args->a7) && args->a7 != HYP_CLNT_ID) {
+ 		args->a0 = OPTEE_SMC_RETURN_ENOTAVAIL;
+ 		goto out;
+ 	}
+diff --git a/core/arch/arm/kernel/virtualization.c b/core/arch/arm/kernel/virtualization.c
+index fbf80d850..19dc69117 100644
+--- a/core/arch/arm/kernel/virtualization.c
++++ b/core/arch/arm/kernel/virtualization.c
+@@ -339,7 +339,7 @@ bool virt_set_guest(uint16_t guest_id)
+ 	}
+ 	cpu_spin_unlock_xrestore(&prtn_list_lock, exceptions);
+ 
+-	return guest_id == HYP_CLNT_ID;
++	return false;
+ }
+ 
+ void virt_unset_guest(void)
+-- 
+2.43.0
+

--- a/meta-xt-domx-gen4/recipes-bsp/optee/optee-os_git.bbappend
+++ b/meta-xt-domx-gen4/recipes-bsp/optee/optee-os_git.bbappend
@@ -10,6 +10,7 @@ EXTRA_OEMAKE += "CFG_VIRTUALIZATION=y \
 
 SRC_URI:append = " \
     file://0001-plat-rcar_gen4-extend-memory-available-to-OP-TEE.patch \
+    file://0002-arm-virtualization-don-t-allow-hypervisor-to-issue-s.patch \
 "
 
 python __anonymous () {


### PR DESCRIPTION
This PR includes two patches:

 - Fix memory layout so OP-TEE does not try to overwrite ARM-TF (aka BL31) memory
 - Fix OP-TEE crash when baremetal kernel tries to communicate with it