### PR TITLE
doc: Few minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ to ensure that Xen and DomD/DomU will work correctly.
 
 # Documentation
 
-- [Building][]
+- [Building and booting][]
 - [Virtualization][]
 - [TC and L3 offload][]
 
-[Building]: ./doc/building.md
+[Building and booting]: ./doc/building.md
 [Virtualization]: ./doc/virtualization.md
 [TC and L3 offload]: ./doc/tc-and-l3-offload.md

--- a/doc/building.md
+++ b/doc/building.md
@@ -143,7 +143,7 @@ For more information about `rouge` check its
 
 Please make sure 'bootargs' variable is unset while running with Xen:
 ```
-unset bootargs
+env delete bootargs
 ```
 
 ### Booting from eMMC using boot script
@@ -156,12 +156,6 @@ section](#writing_emmc).
 
 Generated eMMC image contains the boot script for U-Boot, so to boot
 via eMMC all you need is to set the following variable:
-
-for the Spider board
-```
-setenv bootcmd 'ext2load mmc 0:1 0x83000000 boot-emmc.uImage; source 0x83000000'
-```
-for the S4SK board
 ```
 setenv bootcmd 'ext4load mmc 0:1 0x83000000 boot-emmc.uImage; source 0x83000000'
 ```


### PR DESCRIPTION
- Rename `Building` section to `Building and booting` in README.md.
- Do not separate boot instructions for Spider and S4SK boards.
- Replace `unset bootargs` with `env delete envargs`, because we do not have `unset` command in the u-boot.