### PR TITLE
dom0: domd: fixes required for the camera

### DIFF
--- a/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas/r8a779g0-domd.dts
+++ b/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas/r8a779g0-domd.dts
@@ -139,18 +139,6 @@
 	status = "okay";
 };
 
-&canfd {
-	status = "disabled";
-};
-
-&io_expander_a {
-	status = "okay";
-};
-
-&tsc {
-	status = "disabled";
-};
-
 &pciec0 {
 	status = "okay";
 	ranges = <0x82000000 0 0x30000000 0 0x30000000 0 0x8000000>;
@@ -282,21 +270,21 @@
 	status = "okay";
 };
 
-&vin00          { status = "disabled";};
-&vin01          { status = "disabled";};
-&vin02          { status = "disabled";};
-&vin03          { status = "disabled";};
-&vin10          { status = "disabled";};
-&vin11          { status = "disabled";};
-&vin12          { status = "disabled";};
-&vin13          { status = "disabled";};
-&csi40		   	{ status = "disabled";};
-&csi41		   	{ status = "disabled";};
+&vin00          { status = "okay";};
+&vin01          { status = "okay";};
+&vin02          { status = "okay";};
+&vin03          { status = "okay";};
+&vin10          { status = "okay";};
+&vin11          { status = "okay";};
+&vin12          { status = "okay";};
+&vin13          { status = "okay";};
+&csi40		   	{ status = "okay";};
+&csi41		   	{ status = "okay";};
 
 &gmsl0 {
-	status = "disabled";
+	status = "okay";
 };
 
 &gmsl1 {
-	status = "disabled";
+	status = "okay";
 };

--- a/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas/r8a779g0-xen.dts
+++ b/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas/r8a779g0-xen.dts
@@ -160,6 +160,8 @@
 &dsi1 { xen,passthrough; };
 &isp0 { xen,passthrough; };
 &isp1 { xen,passthrough; };
+&cisp0 { xen,passthrough; };
+&cisp1 { xen,passthrough; };
 
 &soc {
     /delete-node/video@e6ef4000;

--- a/meta-xt-prod-devel-rcar-control-gen4/recipes-guests/domd/files/domd-whitehawk.cfg
+++ b/meta-xt-prod-devel-rcar-control-gen4/recipes-guests/domd/files/domd-whitehawk.cfg
@@ -51,6 +51,7 @@ dt_passthrough_nodes = [
     "/refclk",
     "/regulator-1p8v",
     "/regulator-3p3v",
+    "/pcie_bus",
     "/reserved-memory",
 ]
 
@@ -75,6 +76,8 @@ dtdev = [
     "/soc/video@e6efa000",
     "/soc/video@e6efb000",
     "/soc/gsx@fd000000",
+    "/soc/cisp@fec00000",
+    "/soc/cisp@fee00000",
 ]
 
 irqs = [
@@ -128,8 +131,36 @@ irqs = [
     583,
 # du0
     555,
+# video@e6ef0000
+    561,
+# video@e6ef1000
+    562,
+# video@e6ef2000
+    563,
+# video@e6ef3000
+    564,
+# video@e6ef8000
+    569,
+# video@e6ef9000
+    570,
+# video@e6efa000
+    571,
+# video@e6efb000
+    572,
+# csi2@fe500000
+    531,
+# csi2@fe540000
+    532,
+#isp@fed00000
+    505,
+#isp@fed20000
+    506,
 # gsx@fd000000
     496,
+#cisp0@fec00000
+    507,
+#cisp1@fee00000
+    508,
 ]
 
 iomem = [
@@ -193,7 +224,7 @@ iomem = [
 #gpio@e6061980
     "e6061,1",
 #pcie@e65d0000
-    #"e65d0,3", vpci dbi
+    "e65d0,3",
 #pcie@e65d0000
     "e65d3,2",
 #pcie@e65d0000
@@ -203,7 +234,7 @@ iomem = [
 #pcie@e65d0000
     "e65d7,1",
 #pcie@e65d0000
-    #"fe000,400", vpci config
+    "fe000,400",
 #pcie bar
     "30000,8000",
 #pcie@e65d8000
@@ -242,6 +273,34 @@ iomem = [
     "fed90,10",
 #dsc@feb8d000
     "feb8d,1",
+#video@e6ef0000
+    "e6ef0,1",
+#video@e6ef1000
+    "e6ef1,1",
+#video@e6ef2000
+    "e6ef2,1",
+#video@e6ef3000
+    "e6ef3,1",
+#video@e6ef8000
+    "e6ef8,1",
+#video@e6ef9000
+    "e6ef9,1",
+#video@e6efa000
+    "e6efa,1",
+#video@e6efb000
+    "e6efb,1",
+#csi2@fe500000
+    "fe500,40",
+#csi2@fe540000
+    "fe540,40",
+#isp@fed00000
+    "fed00,10",
+#isp@fed20000
+    "fed20,10",
 #gsx@fd000000
     "fd000,800",
+#cisp0@fec00000
+    "fec00,100",
+#cisp1@fee00000
+    "fee00,100",
 ]

--- a/meta-xt-prod-devel-rcar-control-gen4/recipes-guests/domu/files/domu-whitehawk.cfg
+++ b/meta-xt-prod-devel-rcar-control-gen4/recipes-guests/domu/files/domu-whitehawk.cfg
@@ -45,57 +45,9 @@ dtdev = [
 ]
 
 irqs = [
-# video@e6ef0000
-    561,
-# video@e6ef1000
-    562,
-# video@e6ef2000
-    563,
-# video@e6ef3000
-    564,
-# video@e6ef8000
-    569,
-# video@e6ef9000
-    570,
-# video@e6efa000
-    571,
-# video@e6efb000
-    572,
-# csi2@fe500000
-    531,
-# csi2@fe540000
-    532,
-#isp@fed00000
-    505,
-#isp@fed20000
-    506,
 ]
 
 iomem = [
-#video@e6ef0000
-    "e6ef0,1",
-#video@e6ef1000
-    "e6ef1,1",
-#video@e6ef2000
-    "e6ef2,1",
-#video@e6ef3000
-    "e6ef3,1",
-#video@e6ef8000
-    "e6ef8,1",
-#video@e6ef9000
-    "e6ef9,1",
-#video@e6efa000
-    "e6efa,1",
-#video@e6efb000
-    "e6efb,1",
-#csi2@fe500000
-    "fe500,40",
-#csi2@fe540000
-    "fe540,40",
-#isp@fed00000
-    "fed00,10",
-#isp@fed20000
-    "fed20,10",
 #chipid@fff00044                               
     "fff00,1",   
     "e60a0,1",


### PR DESCRIPTION
This commit changes domd.dts, xen.dts, domd.cfg and domu.cfg so we have proper devices in domd to run camera.

Commit should be considered as the fixup, and be squashed into previous commits.