### PR TITLE
yaml: move common_data inside the build directory

### DIFF
--- a/prod-devel-rcar4.yaml
+++ b/prod-devel-rcar4.yaml
@@ -42,8 +42,8 @@ common_data:
 
   # Common configuration options for all yocto-based domains
   conf: &COMMON_CONF
-    - [SSTATE_DIR, "${TOPDIR}/../../../common_data/sstate"]
-    - [DL_DIR, "${TOPDIR}/../../../common_data/downloads"]
+    - [SSTATE_DIR, "${TOPDIR}/../common_data/sstate"]
+    - [DL_DIR, "${TOPDIR}/../common_data/downloads"]
 
     # Skip warning about missing "virtualization" distro feature
     - [SKIP_META_VIRT_SANITY_CHECK, "1"]


### PR DESCRIPTION
All common data should be kept inside the build folder.