### PR TITLE
[ON HOLD] Use linux-libc-headers from the meta-xt-common

### DIFF
--- a/layers/meta-xt-domu-gen4/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/layers/meta-xt-domu-gen4/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,5 +1,0 @@
-RENESAS_BSP_URL = "git://github.com/renesas-rcar/linux-bsp.git"
-
-BRANCH = "v5.10.41/rcar-5.1.3.rc5"
-SRCREV = "3429c829ce579530e9269f63009c5eae199dbd0a"
-LINUX_VERSION = "5.10.41"

--- a/prod-devel-rcar4.yaml
+++ b/prod-devel-rcar4.yaml
@@ -201,9 +201,6 @@ components:
         - [XT_KERNEL_BRANCH, "%{XT_KERNEL_BRANCH}"]
         - [XT_KERNEL_REV, "%{XT_KERNEL_REV}"]
         - [IMAGE_INSTALL:append, " iperf3 "]
-        # This is temporary workaround required because we use linux-libc-headers 5.10
-        # and xt-common provides 6.4 already. So we need this bbmask until upgrade to 6.4
-        - [BBMASK:append, " meta-xt-common/meta-xt-domu/recipes-kernel/linux-libc-headers/"]
 
       layers:
         - "../meta-openembedded/meta-oe"


### PR DESCRIPTION
After the rework of the linux-libc-headers recipes in the meta-xt-common we should use those recipes.
No appends are expected to be used.