### PR TITLE
xen: remove the duplicated merge of configs

### DIFF
--- a/layers/meta-xt-domd-gen4/recipes-extended/xen/xen_git.bbappend
+++ b/layers/meta-xt-domd-gen4/recipes-extended/xen/xen_git.bbappend
@@ -3,8 +3,3 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI:append = " \
     file://early_printk.cfg \
 "
-
-do_configure:append() {
-    # merge configuration fragments manually using kconfig's native facilities
-    ${S}/xen/tools/kconfig/merge_config.sh -m -O ${B}/xen ${B}/xen/.config ${WORKDIR}/*.cfg
-}


### PR DESCRIPTION
We do not need to merge configs in the product, because this job is done in the `meta-virtualization` layer in the `xen-hypervisor.inc`.

---
See linked issue #122 for additional details.