### PR TITLE
Align sources for linux and linux-libc-headers, and fix the fetch race

### DIFF
--- a/layers/meta-xt-dom0-gen4/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/layers/meta-xt-dom0-gen4/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,9 +1,3 @@
-RENESAS_BSP_URL = "git://github.com/renesas-rcar/linux-bsp.git"
-
-BRANCH = "v5.10.41/rcar-5.1.3.rc5"
-SRCREV = "3429c829ce579530e9269f63009c5eae199dbd0a"
-LINUX_VERSION = "5.10.41"
-
 # we need to avoid a situation when both linux and linux-libc-headers
 # are fetching the same sources simultaneously because this may result in
 # the rejection from the github

--- a/layers/meta-xt-domd-gen4/recipes-kernel/inc/linux-sources.inc
+++ b/layers/meta-xt-domd-gen4/recipes-kernel/inc/linux-sources.inc
@@ -1,0 +1,3 @@
+RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
+BRANCH = "${XT_KERNEL_BRANCH}"
+SRCREV = "${XT_KERNEL_REV}"

--- a/layers/meta-xt-domd-gen4/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/layers/meta-xt-domd-gen4/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,9 +1,3 @@
-RENESAS_BSP_URL = "git://github.com/renesas-rcar/linux-bsp.git"
-
-BRANCH = "v5.10.41/rcar-5.1.3.rc5"
-SRCREV = "3429c829ce579530e9269f63009c5eae199dbd0a"
-LINUX_VERSION = "5.10.41"
-
 # we need to avoid a situation when both linux and linux-libc-headers
 # are fetching the same sources simultaneously because this may result in
 # the rejection from the github

--- a/layers/meta-xt-domd-gen4/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/layers/meta-xt-domd-gen4/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,3 +1,5 @@
+require recipes-kernel/inc/linux-sources.inc
+
 # we need to avoid a situation when both linux and linux-libc-headers
 # are fetching the same sources simultaneously because this may result in
 # the rejection from the github

--- a/layers/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/layers/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -1,8 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
-BRANCH = "${XT_KERNEL_BRANCH}"
-SRCREV = "${XT_KERNEL_REV}"
+require recipes-kernel/inc/linux-sources.inc
 
 SRC_URI:append = " \
     file://ixgbe.cfg \

--- a/layers/meta-xt-domu-gen4/recipes-kernel/inc/linux-sources.inc
+++ b/layers/meta-xt-domu-gen4/recipes-kernel/inc/linux-sources.inc
@@ -1,0 +1,3 @@
+RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
+BRANCH = "${XT_KERNEL_BRANCH}"
+SRCREV = "${XT_KERNEL_REV}"

--- a/layers/meta-xt-domu-gen4/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/layers/meta-xt-domu-gen4/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,8 +1,4 @@
-RENESAS_BSP_URL = "git://github.com/renesas-rcar/linux-bsp.git"
-
-BRANCH = "v5.10.41/rcar-5.1.3.rc5"
-SRCREV = "3429c829ce579530e9269f63009c5eae199dbd0a"
-LINUX_VERSION = "5.10.41"
+require recipes-kernel/inc/linux-sources.inc
 
 # we need to avoid a situation when both linux and linux-libc-headers
 # are fetching the same sources simultaneously because this may result in

--- a/layers/meta-xt-domu-gen4/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/layers/meta-xt-domu-gen4/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -1,8 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
-BRANCH = "${XT_KERNEL_BRANCH}"
-SRCREV = "${XT_KERNEL_REV}"
+require recipes-kernel/inc/linux-sources.inc
 
 SRC_URI:append = "\
     file://r8a779f0-${MACHINE}-domu.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \


### PR DESCRIPTION
- linux-libc-headers: fetch after linux only
- linux: use the same sources for libc headers