### PR TITLE
domu: remove an outdated comment

### DIFF
--- a/layers/meta-xt-dom0-gen4/recipes-guests/domu/files/domu-vdevices.cfg
+++ b/layers/meta-xt-dom0-gen4/recipes-guests/domu/files/domu-vdevices.cfg
@@ -2,9 +2,6 @@
 # DomU virtual devices
 # =====================================================================
 
-# See additional comment above line 'extra = ' in machine dependent config.
-# In case boot from network - comment out 'disk' AND use line with 'root=/dev/nfs' in machine dependent config.
-# In case boot from block device - uncomment 'disk' AND use line with 'root=/dev/xvda1' (or 'root=/dev/vda') in machine dependent config.
 disk = [ 'backend=DomD, phy:/dev/STORAGE_PART3, xvda1' ]
 
 # We use predefined MAC addresses for domains:


### PR DESCRIPTION
As far as we use the domu-set-root script with the corresponding u-boot scripts, we do not have to change the boot device manually, so the comment is not relevant.