### PR TITLE
yaml: change URL for the meta-openembedded

### DIFF
--- a/prod-devel-rcar4.yaml
+++ b/prod-devel-rcar4.yaml
@@ -24,7 +24,7 @@ common_data:
       url: "git://git.yoctoproject.org/poky"
       rev: "1678bb9ee2a1ce476b5b153d9e79bb9813c33574" # scarthgap
     - type: git
-      url: "git://git.openembedded.org/meta-openembedded"
+      url: "https://github.com/openembedded/meta-openembedded"
       rev: "1235dd4ed4a57e67683c045ad76b6a0f9e896b45" # scarthgap
     - type: git
       url: "git://git.yoctoproject.org/meta-virtualization"


### PR DESCRIPTION
According to the https://www.openembedded.org/wiki/Mirrors it is recommened to use the mirror on github.com for the fetching.