### PR TITLE
optee: fix machine suffix handling and add tee.srec symlink

### DIFF
--- a/layers/meta-xt-domx-gen4/recipes-security/optee/optee-os_4.1.0.bbappend
+++ b/layers/meta-xt-domx-gen4/recipes-security/optee/optee-os_4.1.0.bbappend
@@ -5,3 +5,9 @@ EXTRA_OEMAKE += " CFG_NS_VIRTUALIZATION=y CFG_VIRT_GUEST_COUNT=3"
 do_install:append() {
     install -m 644 ${B}/core/tee.srec ${D}${nonarch_base_libdir}/firmware/tee-${MACHINE}.srec
 }
+
+do_deploy:append() {
+    if [ -f "${DEPLOYDIR}/optee/tee-${MACHINE}.srec" ]; then
+        ln -sfr "${DEPLOYDIR}/optee/tee-${MACHINE}.srec" "${DEPLOYDIR}/tee.srec"
+    fi
+}

--- a/layers/meta-xt-domx-gen4/recipes-security/optee/optee-os_4.1.0.bbappend
+++ b/layers/meta-xt-domx-gen4/recipes-security/optee/optee-os_4.1.0.bbappend
@@ -3,5 +3,5 @@ require optee.inc
 EXTRA_OEMAKE += " CFG_NS_VIRTUALIZATION=y CFG_VIRT_GUEST_COUNT=3"
 
 do_install:append() {
-    install -m 644 ${B}/core/tee.srec ${D}${nonarch_base_libdir}/firmware/tee-spider.srec
+    install -m 644 ${B}/core/tee.srec ${D}${nonarch_base_libdir}/firmware/tee-${MACHINE}.srec
 }


### PR DESCRIPTION
The previous install rule hardcoded the "spider" suffix in the
"tee.srec" filename, regardless of the selected machine
("spider" or "s4sk").

This caused an error when running the "boot_artifacts" for the "s4sk"
machine, because it expected "tee-s4sk.srec", but really
"tee-spider.srec" was created.

Also  added creates a symlink "tee.srec" in the deploy directory that
always points to the actual "tee-${MACHINE}.srec", regardless of the
selected machine.