### PR TITLE
yaml: fix Yocto repository URLs

### DIFF
--- a/prod-devel-rcar4.yaml
+++ b/prod-devel-rcar4.yaml
@@ -21,13 +21,13 @@ common_data:
   # Sources used by all yocto-based domains
   sources: &COMMON_SOURCES
     - type: git
-      url: "git://git.yoctoproject.org/poky"
+      url: "https://git.yoctoproject.org/poky"
       rev: "1678bb9ee2a1ce476b5b153d9e79bb9813c33574" # scarthgap
     - type: git
       url: "https://github.com/openembedded/meta-openembedded"
       rev: "1235dd4ed4a57e67683c045ad76b6a0f9e896b45" # scarthgap
     - type: git
-      url: "git://git.yoctoproject.org/meta-virtualization"
+      url: "https://git.yoctoproject.org/meta-virtualization"
       rev: "66ee8d268db25a9f2848bda6858c284c745f549f" # scarthgap
     - type: git
       url: "https://github.com/xen-troops/meta-xt-common.git"
@@ -140,7 +140,7 @@ components:
       - *COMMON_SOURCES
       - *DOMD_DOMU_SOURCES
       - type: git
-        url: git://git.yoctoproject.org/meta-selinux
+        url: https://git.yoctoproject.org/meta-selinux
         rev: "9f5a46620a07d7b15722593a33e46a4d19392b75" # scarthgap
     builder:
       type: yocto


### PR DESCRIPTION
Update the poky, meta-virtualization, and meta-selinux repository URLs from git protocol to HTTPS to restore successful repository cloning.